### PR TITLE
Accept optional ImageModdable

### DIFF
--- a/Sources/ImageMod/ImageModable.swift
+++ b/Sources/ImageMod/ImageModable.swift
@@ -68,7 +68,7 @@ public extension ImageModable {
     // MARK: Stack
 
     func hStack(_ image: ImageModable?, spacing: CGFloat = 0, alignment: UIStackView.Alignment = .center) -> ImageModable {
-        guard let i = image else { return self }
+        guard let image = image else { return self }
         let rect = image.canvasSize.vAlign(in: canvasSize, alignment: alignment)
         return self
             .padded(right: rect.maxX + spacing)
@@ -81,7 +81,7 @@ public extension ImageModable {
     }
 
     func vStack(_ image: ImageModable?, spacing: CGFloat = 0, alignment: UIStackView.Alignment = .center) -> ImageModable {
-        guard let i = image else { return self }
+        guard let image = image else { return self }
         let rect = image.canvasSize.hAlign(in: canvasSize, alignment: alignment)
         return self
             .padded(bottom: rect.maxY + spacing)
@@ -94,7 +94,7 @@ public extension ImageModable {
     }
 
     func zStack(_ overlay: ImageModable?, alignment: UIView.ContentMode = .center) -> ImageModable {
-        guard let i = image else { return self }
+        guard let overlay = overlay else { return self }
         let rect = overlay.canvasSize.align(in: canvasSize, alignment: alignment)
         return with(overlay
             .scaled(to: rect.size)

--- a/Sources/ImageMod/ImageModable.swift
+++ b/Sources/ImageMod/ImageModable.swift
@@ -67,7 +67,8 @@ public extension ImageModable {
 
     // MARK: Stack
 
-    func hStack(_ image: ImageModable, spacing: CGFloat = 0, alignment: UIStackView.Alignment = .center) -> ImageModable {
+    func hStack(_ image: ImageModable?, spacing: CGFloat = 0, alignment: UIStackView.Alignment = .center) -> ImageModable {
+        guard let i = image else { return self }
         let rect = image.canvasSize.vAlign(in: canvasSize, alignment: alignment)
         return self
             .padded(right: rect.maxX + spacing)
@@ -79,7 +80,8 @@ public extension ImageModable {
         )
     }
 
-    func vStack(_ image: ImageModable, spacing: CGFloat = 0, alignment: UIStackView.Alignment = .center) -> ImageModable {
+    func vStack(_ image: ImageModable?, spacing: CGFloat = 0, alignment: UIStackView.Alignment = .center) -> ImageModable {
+        guard let i = image else { return self }
         let rect = image.canvasSize.hAlign(in: canvasSize, alignment: alignment)
         return self
             .padded(bottom: rect.maxY + spacing)
@@ -91,7 +93,8 @@ public extension ImageModable {
         )
     }
 
-    func zStack(_ overlay: ImageModable, alignment: UIView.ContentMode = .center) -> ImageModable {
+    func zStack(_ overlay: ImageModable?, alignment: UIView.ContentMode = .center) -> ImageModable {
+        guard let i = image else { return self }
         let rect = overlay.canvasSize.align(in: canvasSize, alignment: alignment)
         return with(overlay
             .scaled(to: rect.size)


### PR DESCRIPTION
This would allow to pass results from functions that may return
optional ImageModables.

This add the convenience of not breaking the chaining of moding operations.

Before the PR:

```swift
let image = someModable
    .vStack(someOverlay)
var imageWithNewOverlay: ImageModable
if let someNewLayout = maybeNewOverlay(someArg) {
    imageWithNewOverlay = image.vStack(someNewLayout)
} else {
    imageWithNewOverlay = image
}

return imageWithNewOverlay
```

With this PR:

```swift
return someModable
    .vStack(someOverlay)
    .vStack(maybeNewOverlay(someArg))
```